### PR TITLE
Support configuring CA bundle & proxy via env vars

### DIFF
--- a/smartystreets_python_sdk/requests_sender.py
+++ b/smartystreets_python_sdk/requests_sender.py
@@ -18,8 +18,11 @@ class RequestsSender:
         if self.debug:
             print_request_data(prepped_request)
 
+        settings = self.session.merge_environment_settings(
+            prepped_request.url, prepped_proxies, None, None, None
+        )
         try:
-            response = self.session.send(prepped_request, timeout=self.max_timeout, proxies=prepped_proxies)
+            response = self.session.send(prepped_request, timeout=self.max_timeout, **settings)
         except Exception as e:
             return Response(None, None, e)
 
@@ -30,7 +33,7 @@ class RequestsSender:
 
     def build_proxies(self):
         if not self.proxy:
-            return None
+            return {}
         if not self.proxy.host:
             raise smarty.exceptions.SmartyException('Proxy must have a valid host (including port)')
 


### PR DESCRIPTION
When a proxy MITMs the connection between the client and the API, the client may need to instruct the requests library to verify the API's TLS certificate against a custom certificate authority bundle. Unfortunately it is not currently possible to do so.

Fortunately, since requests' [prepared request](https://requests.readthedocs.io/en/stable/user/advanced/#prepared-requests) is being used, we can merge environment settings with session and request settings via [`requests.Session.merge_environment_settings`](https://requests.readthedocs.io/en/stable/api/#requests.Session.merge_environment_settings). This is because, according to the [documentation](https://requests.readthedocs.io/en/stable/user/advanced/#prepared-requests):

> When you are using the prepared request flow, keep in mind that it does not take into account the environment. This can cause problems if you are using environment variables to change the behaviour of requests. For example: Self-signed SSL certificates specified in `REQUESTS_CA_BUNDLE` will not be taken into account. As a result an `SSL: CERTIFICATE_VERIFY_FAILED` is thrown.

With this change, the [`REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE`](https://github.com/psf/requests/blob/v2.23.0/requests/sessions.py#L704-L705) environment variables will instruct requests to verify the API's TLS certificate against a custom certificate authority bundle.

Also, requests will use a proxy if certain [environment variables](https://requests.readthedocs.io/en/stable/user/advanced/#proxies) are set. If a proxy is configured via the SDK's [`with_proxy`](https://github.com/smartystreets/smartystreets-python-sdk/blob/4.4.1/smartystreets_python_sdk/client_builder.py#L78) function, `with_proxy` will override proxy-related environment variables.

FYI: @seunginah