### PR TITLE
Include international autocomplete package in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'smartystreets_python_sdk.international_street',
         'smartystreets_python_sdk.us_reverse_geo',
         'smartystreets_python_sdk.us_autocomplete_pro'
+        'smartystreets_python_sdk.international_autocomplete',
     ],
     version=__version__,
     description='An official library to help Python developers easily access the SmartyStreets APIs',


### PR DESCRIPTION
Right now the new package is not included and so the new package will not be installed. This is causing the new conda distribution to fail. https://github.com/conda-forge/smartystreets_python_sdk-feedstock/pull/8