### PR TITLE
Fix Http Proxy Issue

### DIFF
--- a/examples/us_enrichment_example.py
+++ b/examples/us_enrichment_example.py
@@ -27,7 +27,7 @@ def run():
     # https://www.smartystreets.com/docs/cloud/licensing
     client = ClientBuilder(credentials).with_licenses(["us-property-data-principal-cloud"]).build_us_enrichment_api_client()
     # client = ClientBuilder(credentials).with_custom_header({'User-Agent': 'smartystreets (python@0.0.0)', 'Content-Type': 'application/json'}).build_us_enrichment_api_client()
-    # client = ClientBuilder(credentials).with_proxy('localhost:8080', 'user', 'password').build_us_street_api_client()
+    # client = ClientBuilder(credentials).with_http_proxy('localhost:8080', 'user', 'password').build_us_street_api_client()
     # Uncomment the line above to try it with a proxy instead
 
     smarty_key = "1682393594"

--- a/examples/us_street_single_address_example.py
+++ b/examples/us_street_single_address_example.py
@@ -28,7 +28,7 @@ def run():
     # https://www.smartystreets.com/docs/cloud/licensing
     client = ClientBuilder(credentials).with_licenses(["us-core-cloud"]).build_us_street_api_client()
     # client = ClientBuilder(credentials).with_custom_header({'User-Agent': 'smartystreets (python@0.0.0)', 'Content-Type': 'application/json'}).build_us_street_api_client()
-    # client = ClientBuilder(credentials).with_proxy('localhost:8080', 'user', 'password').build_us_street_api_client()
+    # client = ClientBuilder(credentials).with_http_proxy('localhost:8080', 'user', 'password').build_us_street_api_client()
     # Uncomment the line above to try it with a proxy instead
 
     # Documentation for input fields can be found at:

--- a/smartystreets_python_sdk/client_builder.py
+++ b/smartystreets_python_sdk/client_builder.py
@@ -84,15 +84,28 @@ class ClientBuilder:
         self.url_prefix = base_url
         return self
 
-    def with_proxy(self, host, username=None, password=None):
+    def with_http_proxy(self, host, username=None, password=None):
         """
-        Assigns a proxy through which to send all Lookups.
+        Assigns a http proxy through which to send all Lookups.
         :param host: The proxy host including port, but not scheme. (example: localhost:8080)
         :param username: Username to authenticate with the proxy server
         :param password: Password to authenticate with the proxy server
         :return: Returns self to accommodate method chaining.
         """
-        self.proxy = smarty.Proxy(host, username, password)
+        full_host = 'http://' + host
+        self.proxy = smarty.Proxy(full_host, username, password)
+        return self
+    
+    def with_https_proxy(self, host, username=None, password=None):
+        """
+        Assigns a https proxy through which to send all Lookups.
+        :param host: The proxy host including port, but not scheme. (example: localhost:8080)
+        :param username: Username to authenticate with the proxy server
+        :param password: Password to authenticate with the proxy server
+        :return: Returns self to accommodate method chaining.
+        """
+        full_host = 'https://' + host
+        self.proxy = smarty.Proxy(full_host, username, password)
         return self
 
     def with_custom_header(self, custom_header):

--- a/smartystreets_python_sdk/requests_sender.py
+++ b/smartystreets_python_sdk/requests_sender.py
@@ -32,25 +32,15 @@ class RequestsSender:
         if (self.proxy.host == 'http://' or self.proxy.host =='https://'):
             raise smarty.exceptions.SmartyException('Proxy must have a valid host (including port)')
 
-<<<<<<< HEAD
         proxy_string = self.proxy.host
-=======
-        proxy_string = 'http://'
->>>>>>> 3bbb4543a6da6668c078b66fe54cbfefbac4be6a
 
         if self.proxy.username:
             proxy_string += '{}:{}@'.format(self.proxy.username, self.proxy.password)
 
-<<<<<<< HEAD
         if ('https://' in self.proxy.host):
             return {'https': proxy_string}
         else:
             return {'http': proxy_string, 'https': proxy_string}
-=======
-        proxy_string += self.proxy.host
-
-        return {'http': proxy_string}
->>>>>>> 3bbb4543a6da6668c078b66fe54cbfefbac4be6a
 
 
 def build_request(smarty_request):

--- a/smartystreets_python_sdk/requests_sender.py
+++ b/smartystreets_python_sdk/requests_sender.py
@@ -29,17 +29,18 @@ class RequestsSender:
     def build_proxies(self):
         if not self.proxy:
             return {}
-        if not self.proxy.host:
+        if (self.proxy.host == 'http://' or self.proxy.host =='https://'):
             raise smarty.exceptions.SmartyException('Proxy must have a valid host (including port)')
 
-        proxy_string = 'https://'
+        proxy_string = self.proxy.host
 
         if self.proxy.username:
             proxy_string += '{}:{}@'.format(self.proxy.username, self.proxy.password)
 
-        proxy_string += self.proxy.host
-
-        return {'https': proxy_string}
+        if ('https://' in self.proxy.host):
+            return {'https': proxy_string}
+        else:
+            return {'http': proxy_string, 'https': proxy_string}
 
 
 def build_request(smarty_request):


### PR DESCRIPTION
Proxy strings in request.py were being set to https with a full https string, not allowing for the use of a http proxy. splitting the with_proxy method into two separate methods for http and https is the proposed fix