### PR TITLE
Removed references to the US Autocomplete Basic API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         'smartystreets_python_sdk.us_street',
         'smartystreets_python_sdk.us_zipcode',
         'smartystreets_python_sdk.us_extract',
-        'smartystreets_python_sdk.us_autocomplete',
         'smartystreets_python_sdk.international_street',
         'smartystreets_python_sdk.us_reverse_geo',
         'smartystreets_python_sdk.us_autocomplete_pro',

--- a/smartystreets_python_sdk/client_builder.py
+++ b/smartystreets_python_sdk/client_builder.py
@@ -28,7 +28,6 @@ class ClientBuilder:
         self.licenses = []
         self.INTERNATIONAL_STREET_API_URL = "https://international-street.api.smarty.com/verify"
         self.INTERNATIONAL_AUTOCOMPLETE_API_URL = "https://international-autocomplete.api.smarty.com/v2/lookup"
-        self.US_AUTOCOMPLETE_API_URL = "https://us-autocomplete.api.smarty.com/suggest"
         self.US_AUTOCOMPLETE_PRO_API_URL = "https://us-autocomplete-pro.api.smarty.com/lookup"
         self.US_EXTRACT_API_URL = "https://us-extract.api.smarty.com"
         self.US_STREET_API_URL = "https://us-street.api.smarty.com/street-address"

--- a/smartystreets_python_sdk/international_autocomplete/client.py
+++ b/smartystreets_python_sdk/international_autocomplete/client.py
@@ -6,7 +6,7 @@ from smartystreets_python_sdk.international_autocomplete import Candidate
 class Client:
     def __init__(self, sender, serializer):
         """
-        It is recommended to instantiate this class using ClientBuilder.build_us_autocomplete_api_client()
+        It is recommended to instantiate this class using ClientBuilder.build_international_autocomplete_api_client()
         """
         self.sender = sender
         self.serializer = serializer


### PR DESCRIPTION
A reference to the US Autocomplete Basic API package in setup.py was causing the build process to fail. This PR removes that reference, along with a couple others.