### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Changed "description-file" to "description_file", since Python 3.10.14 is creating the following error while running "!pip install smartystreets_python_sdk" in AWS SageMaker Jupyter notebook: 

Usage of dash-separated 'description-file' will not be supported in future
              versions. Please use the underscore name 'description_file' instead.

Please make sure this change is made asap. Thank you.