### PR TITLE
reverse_geo 422 error handling fix

### DIFF
--- a/smartystreets_python_sdk/status_code_sender.py
+++ b/smartystreets_python_sdk/status_code_sender.py
@@ -8,18 +8,7 @@ class StatusCodeSender:
         self.inner = inner
 
     def parse_rate_limit_response(self, response):
-        error_message = exceptions.TooManyRequestsError(errors.TOO_MANY_REQUESTS)
-        response_json = json.loads(response.payload)
-        if response_json is not None:
-            errors_json = response_json.get('errors')
-            if errors_json is not None:
-                message = ''
-                for current_error in errors_json:
-                    current_message = current_error.get('message')
-                    if current_message is not None:
-                        message = message + current_message + ' '
-                error_message = exceptions.TooManyRequestsError(message.rstrip())
-        return error_message
+        return messageFrom(response, exceptions.TooManyRequestsError(errors.TOO_MANY_REQUESTS))
 
     def send(self, request):
         response = self.inner.send(request)
@@ -29,10 +18,37 @@ class StatusCodeSender:
                 response.error = exceptions.NotModifiedError(errors.NOT_MODIFIED, response.find_header('etag'))
             elif response.status_code == 429:
                 response.error = self.parse_rate_limit_response(response)
+            elif response.status_code in [400, 401, 402, 403, 413, 422]:
+                response.error = messageFrom(response, statuses.get(response.status_code))
             else:
                 response.error = statuses.get(response.status_code)
 
         return response
+
+def messageFrom(response, fallback):
+    message = extract_message(response)
+    if message:
+        return type(fallback)(message)
+    else:
+        return fallback
+
+
+def extract_message(response):
+    try:
+        response_json = json.loads(response.payload)
+    except (ValueError, TypeError):
+        return ''
+    if response_json is None:
+        return ''
+    errors_json = response_json.get('errors')
+    if errors_json is None:
+        return ''
+    message = ''
+    for current_error in errors_json:
+        current_message = current_error.get('message')
+        if current_message is not None:
+            message = message + current_message + ' '
+    return message.rstrip()
 
 
 def ok():

--- a/test/status_code_sender_test.py
+++ b/test/status_code_sender_test.py
@@ -1,7 +1,7 @@
 import unittest
 
-from smartystreets_python_sdk import Response
-from smartystreets_python_sdk.exceptions import NotModifiedError
+from smartystreets_python_sdk import Response, errors
+from smartystreets_python_sdk.exceptions import BadRequestError, NotModifiedError
 from smartystreets_python_sdk.status_code_sender import StatusCodeSender
 from test.mocks import MockSender
 
@@ -41,6 +41,34 @@ class TestStatusCodeSender(unittest.TestCase):
         response = sender.send(None)
 
         self.assertIsNone(response.error)
+
+    def test_client_error_uses_message_from_response(self):
+        payload = '{"errors": [{"message": "Invalid postal code."}]}'
+        inner = MockSender(Response(payload, 400, {}))
+        sender = StatusCodeSender(inner)
+
+        response = sender.send(None)
+
+        self.assertIsInstance(response.error, BadRequestError)
+        self.assertEqual('Invalid postal code.', str(response.error))
+
+    def test_client_error_joins_multiple_messages(self):
+        payload = '{"errors": [{"message": "First problem."}, {"message": "Second problem."}]}'
+        inner = MockSender(Response(payload, 422, {}))
+        sender = StatusCodeSender(inner)
+
+        response = sender.send(None)
+
+        self.assertEqual('First problem. Second problem.', str(response.error))
+
+    def test_client_error_falls_back_when_no_message(self):
+        inner = MockSender(Response("", 400, {}))
+        sender = StatusCodeSender(inner)
+
+        response = sender.send(None)
+
+        self.assertIsInstance(response.error, BadRequestError)
+        self.assertEqual(errors.BAD_REQUEST, str(response.error))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Made 422 and other 400 errors (not including 429) return the error message from the api as part of their error. Added/updated testing accordingly.