### PR TITLE
added/updated us_street match strategy examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ us_street_iana_timezone_api:
 	PYTHONPATH=. python3 examples/us_street_iana_timezone_example.py
 
 us_street_api:
-	PYTHONPATH=. python3 examples/us_street_single_address_example.py && PYTHONPATH=. python3 examples/us_street_multiple_addresses_example.py && PYTHONPATH=. python3 examples/us_street_component_analysis_example.py && PYTHONPATH=. python3 examples/us_street_iana_timezone_example.py
+	PYTHONPATH=. python3 examples/us_street_single_address_example.py && PYTHONPATH=. python3 examples/us_street_multiple_addresses_example.py && PYTHONPATH=. python3 examples/us_street_component_analysis_example.py && PYTHONPATH=. python3 examples/us_street_iana_timezone_example.py && PYTHONPATH=. python3 examples/us_street_match_strategy_example.py
+
+us_street_match_strategy_api:
+	PYTHONPATH=. python3 examples/us_street_match_strategy_example.py
 
 us_zipcode_api:
 	PYTHONPATH=. python3 examples/us_zipcode_single_lookup_example.py && PYTHONPATH=. python3 examples/us_zipcode_multiple_lookups_example.py
@@ -57,4 +60,4 @@ us_zipcode_api:
 examples: international_autocomplete_api international_postal_code_api international_street_api us_autocomplete_pro_api us_enrichment_api us_extract_api us_reverse_geo_api us_street_api us_street_iana_timezone_api us_zipcode_api
 
 
-.PHONY: clean test dependencies package publish examples international_autocomplete_api international_postal_code_api international_street_api us_autocomplete_pro_api us_enrichment_api us_extract_api us_reverse_geo_api us_street_api us_street_iana_timezone_api us_zipcode_api
+.PHONY: clean test dependencies package publish examples international_autocomplete_api international_postal_code_api international_street_api us_autocomplete_pro_api us_enrichment_api us_extract_api us_reverse_geo_api us_street_api us_street_iana_timezone_api us_street_match_strategy_api us_zipcode_api

--- a/examples/us_street_match_strategy_example.py
+++ b/examples/us_street_match_strategy_example.py
@@ -1,0 +1,74 @@
+import os
+
+from smartystreets_python_sdk import BasicAuthCredentials, exceptions, Batch, ClientBuilder
+from smartystreets_python_sdk.us_street import Lookup as StreetLookup
+from smartystreets_python_sdk.us_street.match_type import MatchType
+
+
+def run():
+    # We recommend storing your secret keys in environment variables instead---it's safer!
+    auth_id = os.environ['SMARTY_AUTH_ID']
+    auth_token = os.environ['SMARTY_AUTH_TOKEN']
+
+    credentials = BasicAuthCredentials(auth_id, auth_token)
+    client = ClientBuilder(credentials).build_us_street_api_client()
+
+    # Each address is run through all three match strategies so you can compare how
+    # 'strict', 'enhanced', and 'invalid' each handle a valid, an invalid, and an
+    # ambiguous address.
+    #   - strict:   only returns candidates that are valid, mailable addresses.
+    #   - enhanced: returns a more comprehensive dataset (requires a US Core or Rooftop license).
+    #   - invalid:  most permissive; always returns at least one candidate (a best-guess standardization).
+    # Documentation for input fields: https://smartystreets.com/docs/us-street-api#input-fields
+    addresses = [
+        ("valid (real, deliverable)",   "1600 Amphitheatre Pkwy", "Mountain View", "CA", "94043"),
+        ("invalid (no such address)",   "9999 W 1150 S",          "Provo",         "UT", "84601"),
+        ("ambiguous (missing ZIP/unit)", "1 Rosedale St",         "Baltimore",     "MD", ""),
+    ]
+    strategies = [MatchType.STRICT, MatchType.ENHANCED, MatchType.INVALID]
+
+    batch = Batch()
+    cases = []  # parallel metadata for each lookup, in the order they are added to the batch
+
+    for label, street, city, state, zipcode in addresses:
+        for strategy in strategies:
+            lookup = StreetLookup()
+            lookup.street = street
+            lookup.city = city
+            lookup.state = state
+            lookup.zipcode = zipcode
+            lookup.match = strategy
+            lookup.candidates = 10  # allow ambiguous addresses to return more than one match
+            batch.add(lookup)
+            cases.append((label, "{}, {}, {}".format(street, city, state), strategy.value))
+
+    try:
+        client.send_batch(batch)
+    except exceptions.SmartyException as err:
+        print(err)
+        return
+
+    last_address = None
+    for i, lookup in enumerate(batch):
+        label, address_display, strategy = cases[i]
+
+        if address_display != last_address:
+            print("\n" + "=" * 70)
+            print(" Address: {}  [{}]".format(address_display, label))
+            print("=" * 70)
+            last_address = address_display
+
+        candidates = lookup.result
+        print("\n--- '{}' strategy ---".format(strategy))
+
+        if len(candidates) == 0:
+            print("  0 candidates - no match returned under this strategy.")
+            continue
+
+        print("  {} candidate(s):".format(len(candidates)))
+        for candidate in candidates:
+            print("    [{}] {}  {}".format(candidate.candidate_index, candidate.delivery_line_1, candidate.last_line))
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Added a us_street_match_strategy_example file with examples that compare the outputs of a valid, invalid, and ambiguous address across the valid, invalid, and enriched match strategies.