### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/examples/us_enrichment_etag_example.py
+++ b/examples/us_enrichment_etag_example.py
@@ -1,7 +1,6 @@
 import os
 
 from smartystreets_python_sdk import BasicAuthCredentials, ClientBuilder
-from smartystreets_python_sdk.exceptions import NotModifiedError
 from smartystreets_python_sdk.us_enrichment import BusinessDetailLookup, BusinessLookup
 
 
@@ -44,11 +43,12 @@ def exercise_summary_etag(client, smarty_key):
     second.request_etag = captured_etag
     try:
         client.send_business_lookup(second)
-        print("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Results={}, Etag={}".format(
-            len(second.result or []), display(second.response_etag)))
-    except NotModifiedError as ex:
-        print("  Call 2 (matching Etag): 304 NotModifiedError — caller treats this as cache-valid. Refreshed Etag={}".format(
-            display(ex.response_etag)))
+        if not second.result:
+            print("  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag={}".format(
+                display(second.response_etag)))
+        else:
+            print("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Results={}, Etag={}".format(
+                len(second.result or []), display(second.response_etag)))
     except Exception as ex:
         print("  Call 2 unexpected failure: {}: {}".format(type(ex).__name__, ex))
         return None
@@ -57,10 +57,11 @@ def exercise_summary_etag(client, smarty_key):
     third.request_etag = captured_etag + "X"
     try:
         client.send_business_lookup(third)
-        print("  Call 3 (mutated Etag): 200 as expected. Results={}, Etag={}".format(
-            len(third.result or []), display(third.response_etag)))
-    except NotModifiedError:
-        print("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.")
+        if not third.result:
+            print("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.")
+        else:
+            print("  Call 3 (mutated Etag): 200 as expected. Results={}, Etag={}".format(
+                len(third.result or []), display(third.response_etag)))
     except Exception as ex:
         print("  Call 3 unexpected failure: {}: {}".format(type(ex).__name__, ex))
 
@@ -92,12 +93,13 @@ def exercise_detail_etag(client, business_id):
     second.request_etag = captured_etag
     try:
         client.send_business_detail_lookup(second)
-        second_id = second.result.business_id if second.result is not None else "<null>"
-        print("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. businessId={}, Etag={}".format(
-            second_id, display(second.response_etag)))
-    except NotModifiedError as ex:
-        print("  Call 2 (matching Etag): 304 NotModifiedError — caller treats this as cache-valid. Refreshed Etag={}".format(
-            display(ex.response_etag)))
+        if not second.result:
+            print("  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag={}".format(
+                display(second.response_etag)))
+        else:
+            second_id = second.result.business_id if second.result is not None else "<null>"
+            print("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. businessId={}, Etag={}".format(
+                second_id, display(second.response_etag)))
     except Exception as ex:
         print("  Call 2 unexpected failure: {}: {}".format(type(ex).__name__, ex))
         return
@@ -106,11 +108,12 @@ def exercise_detail_etag(client, business_id):
     third.request_etag = captured_etag + "X"
     try:
         client.send_business_detail_lookup(third)
-        third_id = third.result.business_id if third.result is not None else "<null>"
-        print("  Call 3 (mutated Etag): 200 as expected. businessId={}, Etag={}".format(
-            third_id, display(third.response_etag)))
-    except NotModifiedError:
-        print("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.")
+        if not third.result:
+            print("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.")
+        else:
+            third_id = third.result.business_id if third.result is not None else "<null>"
+            print("  Call 3 (mutated Etag): 200 as expected. businessId={}, Etag={}".format(
+                third_id, display(third.response_etag)))
     except Exception as ex:
         print("  Call 3 unexpected failure: {}: {}".format(type(ex).__name__, ex))
 

--- a/smartystreets_python_sdk/errors.py
+++ b/smartystreets_python_sdk/errors.py
@@ -4,19 +4,23 @@ BAD_CREDENTIALS = "Unauthorized: The credentials were provided incorrectly or di
 PAYMENT_REQUIRED = "Payment Required: There is no active subscription\
  for the account associated with the credentials submitted with the request."
 
-FORBIDDEN = "Because the international service is currently in a limited release phase, only approved accounts" \
-            " may access the service."
+FORBIDDEN = "Forbidden: The request contained valid data and was understood by the server, but the server is\
+ refusing action."
+
+REQUEST_TIMEOUT = "Request timeout error."
 
 REQUEST_ENTITY_TOO_LARGE = "Request Entity Too Large: The request body has exceeded the maximum size."
 
-BAD_REQUEST = "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a\
+BAD_REQUEST = "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a\
  POST request contained malformed JSON."
 
 UNPROCESSABLE_ENTITY = "GET request lacked required fields."
 
-TOO_MANY_REQUESTS = "The rate limit has been exceeded."
+TOO_MANY_REQUESTS = "Too Many Requests: The rate limit for your account has been exceeded."
 
 INTERNAL_SERVER_ERROR = "Internal Server Error."
+
+BAD_GATEWAY = "Bad Gateway error."
 
 SERVICE_UNAVAILABLE = "Service Unavailable. Try again later."
 

--- a/smartystreets_python_sdk/exceptions.py
+++ b/smartystreets_python_sdk/exceptions.py
@@ -22,6 +22,14 @@ class BadRequestError(SmartyException):
     pass
 
 
+class RequestTimeoutError(SmartyException):
+    pass
+
+
+class BadGatewayError(SmartyException):
+    pass
+
+
 class UnprocessableEntityError(SmartyException):
     pass
 

--- a/smartystreets_python_sdk/native_serializer.py
+++ b/smartystreets_python_sdk/native_serializer.py
@@ -9,4 +9,6 @@ class NativeSerializer:
         return json.dumps(obj).encode("UTF-8")
 
     def deserialize(self, payload):
+        if not payload:
+            return {}
         return json.loads(payload)

--- a/smartystreets_python_sdk/status_code_sender.py
+++ b/smartystreets_python_sdk/status_code_sender.py
@@ -14,11 +14,9 @@ class StatusCodeSender:
         response = self.inner.send(request)
 
         if not response.error:
-            if response.status_code == 304:
-                response.error = exceptions.NotModifiedError(errors.NOT_MODIFIED, response.find_header('etag'))
-            elif response.status_code == 429:
+            if response.status_code == 429:
                 response.error = self.parse_rate_limit_response(response)
-            elif response.status_code != 200:
+            elif response.status_code not in (200, 304):
                 response.error = messageFrom(response, fallback_error(response.status_code))
 
         return response

--- a/smartystreets_python_sdk/status_code_sender.py
+++ b/smartystreets_python_sdk/status_code_sender.py
@@ -35,8 +35,16 @@ def messageFrom(response, fallback):
     message = extract_message(response)
     if message:
         return type(fallback)(message)
-    else:
-        return fallback
+    return type(fallback)('{} Body: {}'.format(fallback, unused_body(response)).rstrip())
+
+
+def unused_body(response):
+    payload = response.payload
+    if payload is None:
+        return ''
+    if isinstance(payload, bytes):
+        payload = payload.decode('utf-8', 'replace')
+    return str(payload).strip()
 
 
 def extract_message(response):

--- a/smartystreets_python_sdk/status_code_sender.py
+++ b/smartystreets_python_sdk/status_code_sender.py
@@ -18,12 +18,18 @@ class StatusCodeSender:
                 response.error = exceptions.NotModifiedError(errors.NOT_MODIFIED, response.find_header('etag'))
             elif response.status_code == 429:
                 response.error = self.parse_rate_limit_response(response)
-            elif response.status_code in [400, 401, 402, 403, 413, 422]:
-                response.error = messageFrom(response, statuses.get(response.status_code))
-            else:
-                response.error = statuses.get(response.status_code)
+            elif response.status_code != 200:
+                response.error = messageFrom(response, fallback_error(response.status_code))
 
         return response
+
+def fallback_error(status_code):
+    error = statuses.get(status_code)
+    if error is None:
+        error = exceptions.SmartyException(
+            'The server returned an unexpected HTTP status code: {}'.format(status_code))
+    return error
+
 
 def messageFrom(response, fallback):
     message = extract_message(response)
@@ -51,10 +57,6 @@ def extract_message(response):
     return message.rstrip()
 
 
-def ok():
-    return None
-
-
 def bad_credentials():
     return exceptions.BadCredentialsError(errors.BAD_CREDENTIALS)
 
@@ -65,6 +67,10 @@ def payment_required():
 
 def forbidden():
     return exceptions.ForbiddenError(errors.FORBIDDEN)
+
+
+def request_timeout():
+    return exceptions.RequestTimeoutError(errors.REQUEST_TIMEOUT)
 
 
 def request_entity_too_large():
@@ -83,6 +89,10 @@ def internal_server_error():
     return exceptions.InternalServerError(errors.INTERNAL_SERVER_ERROR)
 
 
+def bad_gateway():
+    return exceptions.BadGatewayError(errors.BAD_GATEWAY)
+
+
 def service_unavailable():
     return exceptions.ServiceUnavailableError(errors.SERVICE_UNAVAILABLE)
 
@@ -91,14 +101,15 @@ def gateway_timeout():
     return exceptions.GatewayTimeoutError(errors.GATEWAY_TIMEOUT)
 
 
-statuses = {200: ok(),
-            401: bad_credentials(),
+statuses = {401: bad_credentials(),
             402: payment_required(),
             403: forbidden(),
+            408: request_timeout(),
             413: request_entity_too_large(),
             400: bad_request(),
             422: unprocessable_entity(),
             500: internal_server_error(),
+            502: bad_gateway(),
             503: service_unavailable(),
             504: gateway_timeout()
             }

--- a/smartystreets_python_sdk/us_enrichment/client.py
+++ b/smartystreets_python_sdk/us_enrichment/client.py
@@ -112,6 +112,8 @@ def send_lookup(client: Client, lookup, response_class=Response):
 
     request = build_request(lookup)
     raw = _dispatch(client, request, lookup)
+    if raw is None:
+        return lookup.result
     lookup.result = [response_class(candidate) for candidate in raw]
     return lookup.result
 
@@ -126,6 +128,8 @@ def send_business_detail_lookup(client: Client, lookup):
     _apply_etag_header(request, lookup)
 
     raw = _dispatch(client, request, lookup)
+    if raw is None:
+        return lookup.result
     if not raw:
         lookup.result = None
     elif len(raw) > 1:
@@ -184,6 +188,8 @@ def _apply_etag_header(request, lookup):
 def _dispatch(client, request, lookup):
     response = client.sender.send(request)
     lookup.response_etag = response.find_header('etag')
+    if response.status_code == 304:
+        return None
     if response.error:
         raise response.error
     raw = client.serializer.deserialize(response.payload)

--- a/test/standard_serializer_test.py
+++ b/test/standard_serializer_test.py
@@ -40,3 +40,10 @@ class TestStandardSerializer(unittest.TestCase):
         self.assertNotIn('city_states', results[2])
         self.assertEqual("invalid_zipcode", results[2]['status'])
         self.assertEqual("Invalid ZIP Code.", results[2]['reason'])
+
+    def test_deserialize_empty_payload_does_not_raise(self):
+        serializer = smarty.NativeSerializer()
+
+        self.assertEqual({}, serializer.deserialize(""))
+        self.assertEqual({}, serializer.deserialize(b""))
+        self.assertEqual({}, serializer.deserialize(None))

--- a/test/status_code_sender_test.py
+++ b/test/status_code_sender_test.py
@@ -1,38 +1,21 @@
 import unittest
 
 from smartystreets_python_sdk import Response, errors, exceptions
-from smartystreets_python_sdk.exceptions import BadRequestError, NotModifiedError
+from smartystreets_python_sdk.exceptions import BadRequestError
 from smartystreets_python_sdk.status_code_sender import StatusCodeSender
 from test.mocks import MockSender
 
 
 class TestStatusCodeSender(unittest.TestCase):
-    def test_not_modified_error_carries_response_etag(self):
+    def test_not_modified_is_not_an_error(self):
         inner = MockSender(Response("", 304, {'Etag': 'server-refreshed-etag'}))
         sender = StatusCodeSender(inner)
 
         response = sender.send(None)
 
-        self.assertIsInstance(response.error, NotModifiedError)
-        self.assertEqual('server-refreshed-etag', response.error.response_etag)
-
-    def test_not_modified_error_response_etag_is_case_insensitive(self):
-        inner = MockSender(Response("", 304, {'eTaG': 'case-insensitive-etag'}))
-        sender = StatusCodeSender(inner)
-
-        response = sender.send(None)
-
-        self.assertIsInstance(response.error, NotModifiedError)
-        self.assertEqual('case-insensitive-etag', response.error.response_etag)
-
-    def test_not_modified_error_response_etag_none_when_header_absent(self):
-        inner = MockSender(Response("", 304, {}))
-        sender = StatusCodeSender(inner)
-
-        response = sender.send(None)
-
-        self.assertIsInstance(response.error, NotModifiedError)
-        self.assertIsNone(response.error.response_etag)
+        self.assertIsNone(response.error)
+        self.assertEqual(304, response.status_code)
+        self.assertEqual('server-refreshed-etag', response.find_header('etag'))
 
     def test_ok_status_has_no_error(self):
         inner = MockSender(Response("", 200, {}))

--- a/test/status_code_sender_test.py
+++ b/test/status_code_sender_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from smartystreets_python_sdk import Response, errors
+from smartystreets_python_sdk import Response, errors, exceptions
 from smartystreets_python_sdk.exceptions import BadRequestError, NotModifiedError
 from smartystreets_python_sdk.status_code_sender import StatusCodeSender
 from test.mocks import MockSender
@@ -69,6 +69,79 @@ class TestStatusCodeSender(unittest.TestCase):
 
         self.assertIsInstance(response.error, BadRequestError)
         self.assertEqual(errors.BAD_REQUEST, str(response.error))
+
+    def test_each_status_code_uses_api_message_when_present(self):
+        payload = '{"errors": [{"message": "API says no"}]}'
+        expected_types = {400: exceptions.BadRequestError,
+                          401: exceptions.BadCredentialsError,
+                          402: exceptions.PaymentRequiredError,
+                          403: exceptions.ForbiddenError,
+                          408: exceptions.RequestTimeoutError,
+                          413: exceptions.RequestEntityTooLargeError,
+                          422: exceptions.UnprocessableEntityError,
+                          429: exceptions.TooManyRequestsError,
+                          500: exceptions.InternalServerError,
+                          502: exceptions.BadGatewayError,
+                          503: exceptions.ServiceUnavailableError,
+                          504: exceptions.GatewayTimeoutError}
+
+        for status_code, error_type in expected_types.items():
+            with self.subTest(status_code=status_code):
+                inner = MockSender(Response(payload, status_code, {}))
+
+                response = StatusCodeSender(inner).send(None)
+
+                self.assertIsInstance(response.error, error_type)
+                self.assertEqual('API says no', str(response.error))
+
+    def test_each_status_code_falls_back_to_standard_message(self):
+        expected_messages = {400: errors.BAD_REQUEST,
+                             401: errors.BAD_CREDENTIALS,
+                             402: errors.PAYMENT_REQUIRED,
+                             403: errors.FORBIDDEN,
+                             408: errors.REQUEST_TIMEOUT,
+                             413: errors.REQUEST_ENTITY_TOO_LARGE,
+                             422: errors.UNPROCESSABLE_ENTITY,
+                             429: errors.TOO_MANY_REQUESTS,
+                             500: errors.INTERNAL_SERVER_ERROR,
+                             502: errors.BAD_GATEWAY,
+                             503: errors.SERVICE_UNAVAILABLE,
+                             504: errors.GATEWAY_TIMEOUT}
+
+        for status_code, message in expected_messages.items():
+            with self.subTest(status_code=status_code):
+                inner = MockSender(Response("", status_code, {}))
+
+                response = StatusCodeSender(inner).send(None)
+
+                self.assertEqual(message, str(response.error))
+
+    def test_standard_messages_match_shared_wording(self):
+        self.assertEqual("Bad Request (Malformed Payload): A GET request lacked a required field or the"
+                         " request body of a POST request contained malformed JSON.", errors.BAD_REQUEST)
+        self.assertEqual("Forbidden: The request contained valid data and was understood by the server,"
+                         " but the server is refusing action.", errors.FORBIDDEN)
+        self.assertEqual("Request timeout error.", errors.REQUEST_TIMEOUT)
+        self.assertEqual("Too Many Requests: The rate limit for your account has been exceeded.",
+                         errors.TOO_MANY_REQUESTS)
+        self.assertEqual("Bad Gateway error.", errors.BAD_GATEWAY)
+
+    def test_unexpected_status_code_falls_back_to_standard_message(self):
+        inner = MockSender(Response("", 418, {}))
+
+        response = StatusCodeSender(inner).send(None)
+
+        self.assertIsInstance(response.error, exceptions.SmartyException)
+        self.assertEqual('The server returned an unexpected HTTP status code: 418', str(response.error))
+
+    def test_unexpected_status_code_uses_api_message_when_present(self):
+        payload = '{"errors": [{"message": "API teapot message"}]}'
+        inner = MockSender(Response(payload, 418, {}))
+
+        response = StatusCodeSender(inner).send(None)
+
+        self.assertIsInstance(response.error, exceptions.SmartyException)
+        self.assertEqual('API teapot message', str(response.error))
 
 
 if __name__ == '__main__':

--- a/test/status_code_sender_test.py
+++ b/test/status_code_sender_test.py
@@ -68,7 +68,7 @@ class TestStatusCodeSender(unittest.TestCase):
         response = sender.send(None)
 
         self.assertIsInstance(response.error, BadRequestError)
-        self.assertEqual(errors.BAD_REQUEST, str(response.error))
+        self.assertEqual(errors.BAD_REQUEST + " Body:", str(response.error))
 
     def test_each_status_code_uses_api_message_when_present(self):
         payload = '{"errors": [{"message": "API says no"}]}'
@@ -114,7 +114,7 @@ class TestStatusCodeSender(unittest.TestCase):
 
                 response = StatusCodeSender(inner).send(None)
 
-                self.assertEqual(message, str(response.error))
+                self.assertEqual(message + " Body:", str(response.error))
 
     def test_standard_messages_match_shared_wording(self):
         self.assertEqual("Bad Request (Malformed Payload): A GET request lacked a required field or the"
@@ -132,7 +132,7 @@ class TestStatusCodeSender(unittest.TestCase):
         response = StatusCodeSender(inner).send(None)
 
         self.assertIsInstance(response.error, exceptions.SmartyException)
-        self.assertEqual('The server returned an unexpected HTTP status code: 418', str(response.error))
+        self.assertEqual('The server returned an unexpected HTTP status code: 418 Body:', str(response.error))
 
     def test_unexpected_status_code_uses_api_message_when_present(self):
         payload = '{"errors": [{"message": "API teapot message"}]}'
@@ -142,6 +142,31 @@ class TestStatusCodeSender(unittest.TestCase):
 
         self.assertIsInstance(response.error, exceptions.SmartyException)
         self.assertEqual('API teapot message', str(response.error))
+
+    def test_fallback_appends_unparseable_body(self):
+        inner = MockSender(Response("not json", 400, {}))
+        sender = StatusCodeSender(inner)
+
+        response = sender.send(None)
+
+        self.assertIsInstance(response.error, BadRequestError)
+        self.assertEqual(errors.BAD_REQUEST + " Body: not json", str(response.error))
+
+    def test_fallback_appends_body_without_messages(self):
+        inner = MockSender(Response('{"errors": []}', 422, {}))
+        sender = StatusCodeSender(inner)
+
+        response = sender.send(None)
+
+        self.assertEqual(errors.UNPROCESSABLE_ENTITY + ' Body: {"errors": []}', str(response.error))
+
+    def test_blank_body_yields_empty_body_label(self):
+        inner = MockSender(Response("   ", 422, {}))
+        sender = StatusCodeSender(inner)
+
+        response = sender.send(None)
+
+        self.assertEqual(errors.UNPROCESSABLE_ENTITY + " Body:", str(response.error))
 
 
 if __name__ == '__main__':

--- a/test/us_enrichment/client_test.py
+++ b/test/us_enrichment/client_test.py
@@ -177,3 +177,19 @@ class TestClient(unittest.TestCase):
 
         function_result = client.send_secondary_count_lookup(lookup)
         self.assertEqual(result, function_result)
+
+
+class TestNotModified(unittest.TestCase):
+    def test_304_is_success_with_refreshed_etag_and_untouched_results(self):
+        from smartystreets_python_sdk import Response as HttpResponse, StatusCodeSender
+        sender = StatusCodeSender(MockSender(HttpResponse("", 304, {'Etag': 'refreshed-etag'})))
+        client = Client(sender, FakeSerializer(None))
+        lookup = PrincipalLookup("xxx")
+        lookup.request_etag = 'old-etag'
+        lookup.result = ['prior']
+
+        result = send_lookup(client, lookup)
+
+        self.assertEqual('refreshed-etag', lookup.response_etag)
+        self.assertEqual(['prior'], lookup.result)
+        self.assertEqual(['prior'], result)


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- API-message extraction now applies to every error status (was limited to 400/401/402/403/413/422/429); added 408/502 with new `RequestTimeoutError`/`BadGatewayError`.
- Unknown non-200 statuses previously produced no error at all; they now raise `SmartyException` with the standard unexpected-status message.

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
